### PR TITLE
masked-input: add masked input as an option

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -54,6 +54,7 @@
     "react-dev-utils": "4.1.0",
     "react-dom": "16.1.1",
     "react-icons": "2.2.7",
+    "react-maskedinput": "4.0.0",
     "react-test-renderer": "16.0.0",
     "style-loader": "0.19.0",
     "stylelint": "8.2.0",

--- a/webapp/src/components/Input/index.js
+++ b/webapp/src/components/Input/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import MdVisibilityOff from 'react-icons/lib/md/visibility-off'
 import MdVisibility from 'react-icons/lib/md/visibility'
+import MaskedInput from 'react-maskedinput'
 
 import { pick } from 'ramda'
 
@@ -60,6 +61,7 @@ class Input extends React.Component {
       className,
       onChange,
       name,
+      mask,
     } = this.props
 
     const inputContainer = classnames(style.inputContainer, {
@@ -92,7 +94,7 @@ class Input extends React.Component {
         }
         <div className={style.boxContainer}>
           <div className={inputContainer}>
-            {multiline
+            {!mask && (multiline
               ? (
                 <textarea
                   rows="1"
@@ -111,6 +113,17 @@ class Input extends React.Component {
                   {...inputProps}
                 />
               )
+            )}
+
+            {mask &&
+              <MaskedInput
+                id={name}
+                name={name}
+                className={className}
+                onChange={disabled ? null : onChange}
+                {...inputProps}
+                mask={mask}
+              />
             }
 
             {this.renderPasswordVisibilityIcon()}
@@ -158,6 +171,7 @@ Input.propTypes = {
   error: PropTypes.string,
   icon: PropTypes.element,
   className: PropTypes.string,
+  mask: PropTypes.string,
 }
 
 Input.defaultProps = {
@@ -170,6 +184,7 @@ Input.defaultProps = {
   icon: null,
   value: '',
   className: '',
+  mask: '',
 }
 
 export default Input

--- a/webapp/src/pages/AddressData/index.js
+++ b/webapp/src/pages/AddressData/index.js
@@ -72,6 +72,7 @@ class AddressData extends Component {
             <Input
               name="cep"
               label="CEP"
+              mask="11111-111"
               value={cep}
               placeholder="Digite o CEP"
               onChange={this.handleInputChange}

--- a/webapp/src/pages/CustomerData/index.js
+++ b/webapp/src/pages/CustomerData/index.js
@@ -93,6 +93,7 @@ class CustomerData extends Component {
               name="documentNumber"
               label="CPF"
               hint=""
+              mask="111.111.111-11"
               value={documentNumber}
               placeholder="Digite seu CPF"
               onChange={this.handleInputChange}
@@ -110,6 +111,7 @@ class CustomerData extends Component {
               name="phoneNumber"
               label="DDD + Telefone"
               hint=""
+              mask="(11) 11111-1111"
               value={phoneNumber}
               placeholder="Digite seu telefone"
               onChange={this.handleInputChange}

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -4106,6 +4106,10 @@ inline-style-prefixer@^3.0.6:
     bowser "^1.7.3"
     css-in-js-utils "^2.0.0"
 
+inputmask-core@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/inputmask-core/-/inputmask-core-2.2.0.tgz#79a75f7f3a4d3312ae95fd2b55a2366a7c91dfba"
+
 inquirer@3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.2.1.tgz#06ceb0f540f45ca548c17d6840959878265fa175"
@@ -6545,7 +6549,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@15.6.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0:
+prop-types@15.6.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -6782,6 +6786,13 @@ react-inspector@^2.2.1:
   dependencies:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
+
+react-maskedinput@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-maskedinput/-/react-maskedinput-4.0.0.tgz#e5130576ebe2c914133982dacb59bf200eba4e0c"
+  dependencies:
+    inputmask-core "^2.1.1"
+    prop-types "^15.5.7"
 
 react-modal@^3.1.2:
   version "3.1.2"


### PR DESCRIPTION
there's no need to create a new component for it, but in the Input
component there's a new `mask` prop, that if passed, will render the
masked input instead of the normal one.

here are the docs for that MaskedInput:
https://github.com/insin/react-maskedinput
https://github.com/insin/inputmask-core#pattern

closes #57 
