### PR TITLE
chore: fix build badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Artis Checkout | [![GitHub license](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/mundipagg/artis/blob/master/LICENSE) [![Travis CI Status](https://travis-ci.org/mundipagg/artis-checkout.svg?branch=master)](https://travis-ci.org/pagarme/artis)
+# Artis Checkout | [![GitHub license](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/mundipagg/artis/blob/master/LICENSE) [![Travis CI Status](https://travis-ci.org/mundipagg/artis.svg?branch=master)](https://travis-ci.org/mundipagg/artis)
 > Projeto em desenvolvimento em parceria entre Mundipagg e Pagar.me.
 
 Este repositório está em fase de desenvolvimento, então muitas mudanças ainda podem acontecer. A ideia é construirmos um Checkout que possa ser facilmente integrado em diversos e-commerces do Brasil, de forma segura e confiável.


### PR DESCRIPTION
it was referring to pagarme/artis instead of mundipagg/artis